### PR TITLE
fix: remove cloudwatch log group resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,12 +96,6 @@ resource "aws_security_group" "this" {
   }
 }
 
-resource "aws_cloudwatch_log_group" "this" {
-  name              = "aws/lambda/${var.name}"
-  retention_in_days = var.log_retention_in_days
-  tags              = var.tags
-}
-
 # === IAM ROLE === #
 
 data "aws_iam_policy_document" "lambda_assume_role" {

--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/lambda/${var.name}"
+  name              = "aws/lambda/${var.name}"
   retention_in_days = var.log_retention_in_days
   tags              = var.tags
 }


### PR DESCRIPTION
## Purpose

Lambdas write to a default path: `aws/lambda/{lambdaName}`. The terraform script was creating a log group in `lambda/{lambdaName}`. There are several duplicate log groups that are empty as a result.

This change will prevent more duplicates from being created.